### PR TITLE
Fixed TimeCreated attribute issue + PUT action bug fix

### DIFF
--- a/Databases and API/StudentSIMS/StudentSIMS/Controllers/StudentsController.cs
+++ b/Databases and API/StudentSIMS/StudentSIMS/Controllers/StudentsController.cs
@@ -53,7 +53,18 @@ namespace StudentSIMS.Controllers
                 return BadRequest();
             }
 
-            _context.Entry(student).State = EntityState.Modified;
+            if (!StudentExists(id))
+            {
+                return BadRequest();
+            }
+
+            var updateStudent = await _context.Student.FirstOrDefaultAsync(s => s.studentId == student.studentId);
+            _context.Entry(updateStudent).State = EntityState.Modified;
+
+            updateStudent.firstName = student.firstName;
+            updateStudent.lastName = student.lastName;
+            updateStudent.emailAddress = student.emailAddress;
+            updateStudent.phoneNumber = student.phoneNumber;
 
             try
             {
@@ -80,6 +91,7 @@ namespace StudentSIMS.Controllers
         [HttpPost]
         public async Task<ActionResult<Student>> PostStudent(Student student)
         {
+            student.timeCreated = DateTime.Now;
             _context.Student.Add(student);
             await _context.SaveChangesAsync();
 

--- a/Databases and API/StudentSIMS/StudentSIMS/Models/Student.cs
+++ b/Databases and API/StudentSIMS/StudentSIMS/Models/Student.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
-using System.Threading.Tasks;
 
 // namespace contains the collections of symbols/methods so each is uniquely identified
 // here the class Student belongs to the namespace StudentSIMS.Models, you can use access
@@ -20,16 +17,14 @@ namespace StudentSIMS.Models
         // generated once when the row is first created, and it cannot be updated
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int studentId { get; set; }
-        // fisrtName is required when adding a Student to the database, and it will have 100 characters max
+        // firstName is required when adding a Student to the database, and it will have 100 characters max
         [Required, MaxLength(100)]
         public string firstName { get; set; }
-        public string midlleName { get; set; }
+        public string middleName { get; set; }
         [Required]
         public string lastName { get; set; }
         public string emailAddress { get; set; }
         public int phoneNumber { get; set; }
-        // assign Timestamp type to the timeCreated attribute
-        [Timestamp]
         public DateTime timeCreated { get; set; }
     }
 }


### PR DESCRIPTION
The [Timestamp] attribute on the TimeCreated property isn't used properly which causes issues and results in an incorrect date being inserted into the database and the boilerplate code for the PUT action causes an internal server error for myself (and others), so I've added fixes for both of these issues.